### PR TITLE
Remove timeout as incompatible with Prefect Flow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,3 @@ jupyter
 notebook
 ipython
 scipy
-timeout-decorator

--- a/weaveio/__version__.py
+++ b/weaveio/__version__.py
@@ -1,2 +1,2 @@
-__version__ = "2023.0.17"
-__changes__ = "query timeout safety"
+__version__ = "2023.0.18"
+__changes__ = "remove query timeout safety"

--- a/weaveio/readquery/parser.py
+++ b/weaveio/readquery/parser.py
@@ -22,7 +22,6 @@ class DeadEndException(Exception):
     pass
 
 
-@timeout_decorator.timeout(120)
 def traverse(graph, start=None, end=None, done=None, ordering=None, views=None):
     """
     traverse the traversal_graph with backtracking

--- a/weaveio/readquery/parser.py
+++ b/weaveio/readquery/parser.py
@@ -7,7 +7,6 @@ import warnings
 import networkx as nx
 import pandas as pd
 from astropy.table import Table
-import timeout_decorator
 
 from .utilities import mask_infs, remove_successive_duplicate_lines, dtype_conversion
 from .digraph import HashedDiGraph, plot_graph, add_start, add_traversal, add_filter, add_aggregation, add_operation, add_return, add_unwind, subgraph_view, get_above_state_traversal_graph, node_dependencies, add_node_reference


### PR DESCRIPTION
This was introduced in philastrophist#41, but it was discovered that this approach (even with use_signals=False) is incompatible with Prefect Flow.