### PR TITLE
Use a more general method of getting only element that also works for a set

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -32,7 +32,7 @@ def main(night):
         if len(fs) == 0:
             logger.info(f'No MOS files found')
         else:
-            data.write_files(*fs, timeout=10*60, debug=False, test_one=False, debug_time=False,
+            data.write_files(*fs, timeout=60*60, debug=False, test_one=False, debug_time=False,
                              debug_params=False, dryrun=False)
 
 

--- a/ingest.py
+++ b/ingest.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+from tqdm import tqdm
+from functools import partialmethod
+
+from weaveio.file import File
+from weaveio.opr3 import Data
+
+import logging
+logger = logging.getLogger(__name__)
+logger.setLevel('DEBUG')
+
+tqdm.__init__ = partialmethod(tqdm.__init__, disable=True)
+
+
+def match_files(filetype, directory, night):
+    """Returns all matching files within a directory"""
+    return (f for f in Path(directory).rglob(f'*{night}/*.fit*') if filetype.match_file(directory, f, None))
+
+
+def find_files(data, night):
+    filelist = []
+    for filetype in data.filetypes:
+        filelist += sorted([i for i in match_files(filetype, data.rootdir, night)], key=lambda f: f.name)
+    return [f for f in filelist if File.check_mos(f)]
+
+
+def main(night):
+    data = Data()
+    logger.info(f'Preparing to ingest data for night {night}')
+    with data.write:
+        fs = find_files(data, night)
+        if len(fs) == 0:
+            logger.info(f'No MOS files found')
+        else:
+            data.write_files(*fs, timeout=10*60, debug=False, test_one=False, debug_time=False,
+                             debug_params=False, dryrun=False)
+
+
+if __name__ == '__main__':
+    import sys
+    main(sys.argv[1])

--- a/ingest.sh
+++ b/ingest.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -Tf
 #PBS -N WL-INGEST
 #PBS -l nodes=1
-#PBS -l walltime=06:00:00
+#PBS -l walltime=12:00:00
 #PBS -l pmem=6gb
 #PBS -k oe
 #PBS -j oe

--- a/ingest.sh
+++ b/ingest.sh
@@ -1,0 +1,29 @@
+#!/bin/sh -Tf
+#PBS -N WL-INGEST
+#PBS -l nodes=1
+#PBS -l walltime=06:00:00
+#PBS -l pmem=6gb
+#PBS -k oe
+#PBS -j oe
+#PBS -v PATH,WEAVEIO_USER,WEAVEIO_PASSWORD
+
+# This should be run as:
+# qsub -V -v NIGHT=20170226 ingest.sh
+# or to submit jobs for lots of nights:
+# ls $WEAVEIO_ROOTDIR/raw/ | grep -v txt | xargs -I{} qsub -V -v NIGHT={} ingest.sh
+
+export WEAVEIO_DB=lorentz
+
+echo ------------------------------------------------------
+echo -n 'Job is running on node '; cat $PBS_NODEFILE
+echo ------------------------------------------------------
+echo $PATH
+SAVED_WEAVEIO_USER=$WEAVEIO_USER
+SAVED_WEAVEIO_PASSWORD=$WEAVEIO_PASSWORD
+export PYTHONUNBUFFERED=1
+cd /home2/bamford/weave-io
+echo Starting ingest `date`
+echo Ingesting night $NIGHT to DB $WEAVEIO_DB
+conda run -n weaveio WEAVEIO_USER=$SAVED_WEAVEIO_USER WEAVEIO_PASSWORD=$SAVED_WEAVEIO_PASSWORD python ingest.py $NIGHT
+echo ------------------------------------------------------
+echo Job ends `date`

--- a/ingest.sh
+++ b/ingest.sh
@@ -27,3 +27,5 @@ echo Ingesting night $NIGHT to DB $WEAVEIO_DB
 conda run -n weaveio WEAVEIO_USER=$SAVED_WEAVEIO_USER WEAVEIO_PASSWORD=$SAVED_WEAVEIO_PASSWORD python ingest.py $NIGHT
 echo ------------------------------------------------------
 echo Job ends `date`
+echo ------------------------------------------------------
+echo ------------------------------------------------------

--- a/validate.py
+++ b/validate.py
@@ -1,0 +1,16 @@
+from tqdm import tqdm
+from functools import partialmethod
+
+from weaveio.opr3 import Data
+
+import logging
+logger = logging.getLogger(__name__)
+logger.setLevel('DEBUG')
+
+tqdm.__init__ = partialmethod(tqdm.__init__, disable=True)
+
+
+if __name__ == '__main__':
+    data = Data()
+    logger.info(f'Preparing to validate data')
+    data.validate()

--- a/validate.sh
+++ b/validate.sh
@@ -1,0 +1,29 @@
+#!/bin/sh -Tf
+#PBS -N WL-VAL
+#PBS -l nodes=1
+#PBS -l walltime=12:00:00
+#PBS -l pmem=6gb
+#PBS -k oe
+#PBS -j oe
+#PBS -v PATH,WEAVEIO_USER,WEAVEIO_PASSWORD
+
+# This should be run as:
+# qsub validate.sh
+
+export WEAVEIO_DB=lorentz
+
+echo ------------------------------------------------------
+echo -n 'Job is running on node '; cat $PBS_NODEFILE
+echo ------------------------------------------------------
+echo $PATH
+SAVED_WEAVEIO_USER=$WEAVEIO_USER
+SAVED_WEAVEIO_PASSWORD=$WEAVEIO_PASSWORD
+export PYTHONUNBUFFERED=1
+cd /home2/bamford/weave-io
+echo Starting validation `date`
+echo Validating data in DB $WEAVEIO_DB
+conda run -n weaveio WEAVEIO_USER=$SAVED_WEAVEIO_USER WEAVEIO_PASSWORD=$SAVED_WEAVEIO_PASSWORD python validate.py
+echo ------------------------------------------------------
+echo Job ends `date`
+echo ------------------------------------------------------
+echo ------------------------------------------------------

--- a/weaveio/data.py
+++ b/weaveio/data.py
@@ -649,8 +649,6 @@ class Data:
                 timed_out = False
                 if not dryrun:
                     try:
-                        self.graph.execute('MATCH (n) remove n._query_hash')
-                        self.graph.execute('MATCH ()-[r]-() remove r._query_hash')
                         results = self.graph.execute(cypher, **params)
                         stats.append(results.stats())
                         timestamp = results.evaluate()
@@ -675,9 +673,6 @@ class Data:
                                 raise ConnectionTimeOutError(f"Connection timed out whilst writing {path}{slc.start}:{slc.stop}:{part} and it failed") from e
                             else:
                                 raise ConnectionError(f"{path} could not be written to the database see neo4j logs for more details") from e
-                    finally:
-                        self.graph.execute('MATCH (n) remove n._query_hash')
-                        self.graph.execute('MATCH ()-[r]-() remove r._query_hash')
                     if timestamp is None:
                         logging.warning(f"This query terminated early due to either an empty input table/data or "
                                         f"a match within the query returned no matches or it timed-out. "

--- a/weaveio/data.py
+++ b/weaveio/data.py
@@ -649,7 +649,7 @@ class Data:
                 timed_out = False
                 if not dryrun:
                     try:
-                        results = self.graph.execute(cypher, **params)
+                        results = self.graph.execute(cypher, remove_query_hash=True, **params)
                         stats.append(results.stats())
                         timestamp = results.evaluate()
                         successful = True
@@ -707,7 +707,7 @@ class Data:
             # df = pd.DataFrame(columns=['elapsed_time', 'fname', 'batch_start', 'batch_end', 'part'])
             # df['elapsed_time'] = elapsed_times
         else:
-            df = pd.DataFrame(columns=['timestamp', 'elapsed_time', 'fname', 'batch_start', 'batch_end'])
+            df = pd.DataFrame(columns=['timestamp', 'elapsed_time', 'fname', 'batch_start', 'batch_end', 'part'])
         if dryrun:
             return
         return df.set_index(['fname', 'batch_start', 'batch_end', 'part'])

--- a/weaveio/graph.py
+++ b/weaveio/graph.py
@@ -141,8 +141,8 @@ class Graph(metaclass=ContextMeta):
                 tries += 1
                 result = self._execute(cypher, d)
                 break
-            except py2neo.errors.TransientError:
-                logger.warning(f'py2neo TransientError, tries: {tries}')
+            except (py2neo.errors.TransientError, py2neo.errors.ClientError):
+                logger.warning(f'py2neo error, tries: {tries}')
                 if tries > 5:
                     raise
         return result

--- a/weaveio/graph.py
+++ b/weaveio/graph.py
@@ -144,9 +144,10 @@ class Graph(metaclass=ContextMeta):
                 result = self._execute(cypher, d, remove_query_hash=remove_query_hash)
                 break
             except (py2neo.errors.TransientError, py2neo.errors.ClientError):
-                logger.warning(f'py2neo error, tries: {tries}')
                 if tries > 5:
                     raise
+                logger.warning(f'py2neo error, tries: {tries}')
+                sleep(0.1)
         return result
 
     def output_for_debug(self,  arrow=False, cmdline=False, silent=False, **payload):

--- a/weaveio/readquery/functions.py
+++ b/weaveio/readquery/functions.py
@@ -57,7 +57,7 @@ def reduce(function, sequence: List, initial=None):
     if not len(sequence):
         return initial
     if initial is None and len(sequence) == 1:
-        return sequence[0]
+        return next(iter(sequence))
     if any(isinstance(s, AttributeQuery) for s in sequence):
         if initial is None:
             initial = sequence[0]


### PR DESCRIPTION
This avoids an error when combining a set of QAG diagnostic statuses in [QAG.diagnostic.combine_failure_statuses](https://github.com/WEAVE-LOFAR/QAG/blob/84efdf938dd05b27cca616e5e6d1241e0e8313d2/diagnostic.py#L203).